### PR TITLE
RootGuard: ensure !Sync

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       - name: miri
         run: |
           rustup toolchain install nightly-2022-08-16
-          rustup default nightly
+          rustup default nightly-2022-08-16
           rustup component add miri
           ./maint/checks/miri.sh
 


### PR DESCRIPTION
There was a soundness bug - the guard could be accessed simultaneously
by multiple threads, invalidating the safety proofs in GuardedRc and
GuardedRefCell, which take a &RootGuard to prove that the current thread
has exclusive access to the corresponding Root.

I verified the problem by adding a test that failed miri. After fixing
the bug, I fixed the test so that it still compiles.

It'd be nice to have a regression test enforcing that the previous
version *doesn't* compile, but I don't know of a straightforward way to
do that.